### PR TITLE
Bump activesupport gem to 5.x on test environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 
 group :test do
   # ActiveSupport required to test compatibility with ActiveSupport Core Extensions.
-  gem 'activesupport', '~> 4.x', require: false
+  gem 'activesupport', '~> 5.x', require: false
   gem 'codeclimate-test-reporter', '~> 1.0', require: false
   gem 'rspec-core', '~> 3.1.7'
   gem 'danger-changelog', '~> 0.1.0', require: false


### PR DESCRIPTION
I'd like to use this gem with Ruby 2.4.0.
I couldn't `bundle install` using Ruby 2.4.0 because old `json` gem is depending activesupport 4.x.